### PR TITLE
Fixes #21104 - Recognize br-ex etc as bridge interfaces

### DIFF
--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -1,7 +1,7 @@
 class FactParser
   delegate :logger, :to => :Rails
   VIRTUAL = /\A([a-z0-9]+)_([a-z0-9]+)\Z/
-  BRIDGES = /\A(vir)?br\d+(_nic)?\Z/
+  BRIDGES = /\A(vir)?br(\d+|-[a-z0-9]+)(_nic)?\Z/
   BONDS = /\A(bond\d+)\Z|\A(lagg\d+)\Z/
   VIRTUAL_NAMES = /#{VIRTUAL}|#{BRIDGES}|#{BONDS}/
 

--- a/test/unit/fact_parser_test.rb
+++ b/test/unit/fact_parser_test.rb
@@ -14,6 +14,13 @@ class FactParserTest < ActiveSupport::TestCase
     refute_match FactParser::BONDS, 'bond0:0'
   end
 
+  test "bridge regexp matches bridges" do
+    assert_match FactParser::BRIDGES, 'br12'
+    assert_match FactParser::BRIDGES, 'br-ex'
+    assert_match FactParser::BRIDGES, 'virbr1'
+    refute_match FactParser::BRIDGES, 'bridge'
+  end
+
   test "default parsers" do
     assert_includes FactParser.parsers.keys, 'puppet'
     assert_equal PuppetFactParser, FactParser.parser_for(:puppet)


### PR DESCRIPTION
Extends the bridge regex pattern to allow bridges named after purpose
like br-ex, br-tun as documented in openstack dvr scenario.